### PR TITLE
fix(app:seed): adding empty where clause for Sequelize destroy calls

### DIFF
--- a/app/templates/e2e/account(auth)/login/login.spec(jasmine).js
+++ b/app/templates/e2e/account(auth)/login/login.spec(jasmine).js
@@ -20,7 +20,7 @@ describe('Login View', function() {
 
   beforeEach(function(done) {
     <% if (filters.mongooseModels) { %>UserModel.removeAsync()<% }
-       if (filters.sequelizeModels) { %>UserModel.destroy()<% } %>
+       if (filters.sequelizeModels) { %>UserModel.destroy({where: {}})<% } %>
       .then(function() {
         <% if (filters.mongooseModels) { %>return UserModel.createAsync(testUser);<% }
            if (filters.sequelizeModels) { %>return UserModel.create(testUser);<% } %>

--- a/app/templates/e2e/account(auth)/login/login.spec(mocha).js
+++ b/app/templates/e2e/account(auth)/login/login.spec(mocha).js
@@ -21,7 +21,7 @@ describe('Login View', function() {
   before(function() {
     return UserModel
       <% if (filters.mongooseModels) { %>.removeAsync()<% }
-         if (filters.sequelizeModels) { %>.destroy()<% } %>
+         if (filters.sequelizeModels) { %>.destroy({where: {}})<% } %>
       .then(function() {
         <% if (filters.mongooseModels) { %>return UserModel.createAsync(testUser);<% }
            if (filters.sequelizeModels) { %>return UserModel.create(testUser);<% } %>
@@ -31,7 +31,7 @@ describe('Login View', function() {
 
   after(function() {
     <% if (filters.mongooseModels) { %>return UserModel.removeAsync();<% }
-       if (filters.sequelizeModels) { %>return UserModel.destroy();<% } %>
+       if (filters.sequelizeModels) { %>return UserModel.destroy({where: {}});<% } %>
   });
 
   it('should include login form with correct inputs and submit button', function() {

--- a/app/templates/e2e/account(auth)/logout/logout.spec(jasmine).js
+++ b/app/templates/e2e/account(auth)/logout/logout.spec(jasmine).js
@@ -18,7 +18,7 @@ describe('Logout View', function() {
 
   beforeEach(function(done) {
     <% if (filters.mongooseModels) { %>UserModel.removeAsync()<% }
-       if (filters.sequelizeModels) { %>UserModel.destroy()<% } %>
+       if (filters.sequelizeModels) { %>UserModel.destroy({where: {}})<% } %>
       .then(function() {
         <% if (filters.mongooseModels) { %>return UserModel.createAsync(testUser);<% }
            if (filters.sequelizeModels) { %>return UserModel.create(testUser);<% } %>

--- a/app/templates/e2e/account(auth)/logout/logout.spec(mocha).js
+++ b/app/templates/e2e/account(auth)/logout/logout.spec(mocha).js
@@ -19,7 +19,7 @@ describe('Logout View', function() {
   beforeEach(function() {
     return UserModel
       <% if (filters.mongooseModels) { %>.removeAsync()<% }
-         if (filters.sequelizeModels) { %>.destroy()<% } %>
+         if (filters.sequelizeModels) { %>.destroy({where: {}})<% } %>
       .then(function() {
         <% if (filters.mongooseModels) { %>return UserModel.createAsync(testUser);<% }
            if (filters.sequelizeModels) { %>return UserModel.create(testUser);<% } %>
@@ -31,7 +31,7 @@ describe('Logout View', function() {
 
   after(function() {
     <% if (filters.mongooseModels) { %>return UserModel.removeAsync();<% }
-       if (filters.sequelizeModels) { %>return UserModel.destroy();<% } %>
+       if (filters.sequelizeModels) { %>return UserModel.destroy({where: {}});<% } %>
   })
 
   describe('with local auth', function() {

--- a/app/templates/e2e/account(auth)/signup/signup.spec(jasmine).js
+++ b/app/templates/e2e/account(auth)/signup/signup.spec(jasmine).js
@@ -37,7 +37,7 @@ describe('Signup View', function() {
 
     it('should signup a new user, log them in, and redirecting to "/"', function(done) {
       <% if (filters.mongooseModels) { %>UserModel.remove(function() {<% }
-         if (filters.sequelizeModels) { %>UserModel.destroy().then(function() {<% } %>
+         if (filters.sequelizeModels) { %>UserModel.destroy({where: {}}).then(function() {<% } %>
         page.signup(testUser);
 
         var navbar = require('../../components/navbar/navbar.po');

--- a/app/templates/e2e/account(auth)/signup/signup.spec(mocha).js
+++ b/app/templates/e2e/account(auth)/signup/signup.spec(mocha).js
@@ -24,7 +24,7 @@ describe('Signup View', function() {
 
   after(function() {
     <% if (filters.mongooseModels) { %>return UserModel.removeAsync();<% }
-       if (filters.sequelizeModels) { %>return UserModel.destroy();<% } %>
+       if (filters.sequelizeModels) { %>return UserModel.destroy({where: {}});<% } %>
   });
 
   it('should include signup form with correct inputs and submit button', function() {
@@ -42,7 +42,7 @@ describe('Signup View', function() {
 
     it('should signup a new user, log them in, and redirecting to "/"', function(done) {
       <% if (filters.mongooseModels) { %>UserModel.remove(function() {<% }
-         if (filters.sequelizeModels) { %>UserModel.destroy().then(function() {<% } %>
+         if (filters.sequelizeModels) { %>UserModel.destroy({where: {}}).then(function() {<% } %>
         page.signup(testUser);
 
         var navbar = require('../../components/navbar/navbar.po');

--- a/app/templates/server/api/thing/thing.controller(models).js
+++ b/app/templates/server/api/thing/thing.controller(models).js
@@ -56,7 +56,7 @@ function removeEntity(res) {
   return function(entity) {
     if (entity) {
       <% if (filters.mongooseModels) { %>return entity.removeAsync()<% }
-         if (filters.sequelizeModels) { %>return entity.destroy()<% } %>
+         if (filters.sequelizeModels) { %>return entity.destroy({where: {}})<% } %>
         .then(function() {
           return res.send(204);
         });

--- a/app/templates/server/api/user(auth)/user.integration.js
+++ b/app/templates/server/api/user(auth)/user.integration.js
@@ -11,7 +11,7 @@ describe('User API:', function() {
   // Clear users before testing
   before(function(done) {
     <% if (filters.mongooseModels) { %>User.remove(function() {<% }
-       if (filters.sequelizeModels) { %>User.destroy().then(function() {<% } %>
+       if (filters.sequelizeModels) { %>User.destroy({where: {}}).then(function() {<% } %>
       <% if (filters.mongooseModels) { %>user = new User({<% }
          if (filters.sequelizeModels) { %>user = User.build({<% } %>
         name: 'Fake User',
@@ -36,7 +36,7 @@ describe('User API:', function() {
   // Clear users after testing
   after(function() {
     <% if (filters.mongooseModels) { %>return User.remove().exec();<% }
-       if (filters.sequelizeModels) { %>return User.destroy();<% } %>
+       if (filters.sequelizeModels) { %>return User.destroy({where: {}});<% } %>
   });
 
   describe('GET /api/users/me', function() {

--- a/app/templates/server/api/user(auth)/user.model.spec(sequelizeModels).js
+++ b/app/templates/server/api/user(auth)/user.model.spec(sequelizeModels).js
@@ -16,12 +16,12 @@ describe('User Model', function() {
   before(function() {
     // Sync and clear users before testing
     User.sync().then(function() {
-      return User.destroy();
+      return User.destroy({where: {}});
     });
   });
 
   afterEach(function() {
-    return User.destroy();
+    return User.destroy({where: {}});
   });
 
   it('should begin with no users', function() {

--- a/app/templates/server/config/seed(models).js
+++ b/app/templates/server/config/seed(models).js
@@ -15,7 +15,7 @@ var Thing = sqldb.Thing;
 <% if (filters.mongooseModels) { %>Thing.find({}).removeAsync()<% }
    if (filters.sequelizeModels) { %>Thing.sync()
   .then(function() {
-    return Thing.destroy();
+    return Thing.destroy({where: {}});
   })<% } %>
   .then(function() {
     <% if (filters.mongooseModels) { %>Thing.create({<% }
@@ -53,7 +53,7 @@ var Thing = sqldb.Thing;
 <% if (filters.mongooseModels) { %>User.find({}).removeAsync()<% }
    if (filters.sequelizeModels) { %>User.sync()
   .then(function() {
-    User.destroy();
+    User.destroy({where: {}});
   })<% } %>
   .then(function() {
     <% if (filters.mongooseModels) { %>User.createAsync({<% }


### PR DESCRIPTION
Sequelize destroy cannot be called without a where
 (https://github.com/sequelize/sequelize/issues/3131),
 this causes the following error message: `Missing where or
 truncate attribute in the options parameter passed to destroy.`